### PR TITLE
Partial refactor, add new strategy for handle build problems

### DIFF
--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/common/HeuristicResult.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/common/HeuristicResult.java
@@ -12,8 +12,8 @@ import org.jetbrains.annotations.Nullable;
 
 public class HeuristicResult {
 
-  private HashMap<Integer, Responsibility> testRun2Responsibility;
-  private HashMap<Integer, Responsibility> buildProblem2Responsibility;
+  private final HashMap<Integer, Responsibility> testRun2Responsibility;
+  private final HashMap<Integer, Responsibility> buildProblem2Responsibility;
 
   public HeuristicResult() {
     testRun2Responsibility = new HashMap<>();

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/heuristics/PreviousResponsibleHeuristic.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/heuristics/PreviousResponsibleHeuristic.java
@@ -3,7 +3,7 @@
 package jetbrains.buildServer.investigationsAutoAssigner.heuristics;
 
 import com.intellij.openapi.diagnostic.Logger;
-import java.util.HashMap;
+import java.util.Map;
 import jetbrains.buildServer.investigationsAutoAssigner.common.Constants;
 import jetbrains.buildServer.investigationsAutoAssigner.common.HeuristicResult;
 import jetbrains.buildServer.investigationsAutoAssigner.common.Responsibility;
@@ -40,7 +40,7 @@ public class PreviousResponsibleHeuristic implements Heuristic {
     SProject sProject = heuristicContext.getProject();
     Iterable<STestRun> sTestRuns = heuristicContext.getTestRuns();
 
-    HashMap<Long, User> testId2Responsible = myInvestigationsManager.findInAudit(sTestRuns, sProject);
+    Map<Long, User> testId2Responsible = myInvestigationsManager.findInAudit(sTestRuns, sProject);
     for (STestRun sTestRun : heuristicContext.getTestRuns()) {
       STest sTest = sTestRun.getTest();
 

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/persistent/StatisticsReporter.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/persistent/StatisticsReporter.java
@@ -10,13 +10,14 @@ import jetbrains.buildServer.investigationsAutoAssigner.utils.CustomParameters;
 import jetbrains.buildServer.serverSide.TeamCityProperties;
 import jetbrains.buildServer.serverSide.executors.ExecutorServices;
 import jetbrains.buildServer.util.StringUtil;
+import org.jetbrains.annotations.NotNull;
 
 public class StatisticsReporter {
   private final StatisticsDao myStatisticsDao;
   private final Statistics myStatistics;
 
-  public StatisticsReporter(StatisticsDaoFactory statisticsDaoFactory,
-                            ExecutorServices executorServices) {
+  public StatisticsReporter(@NotNull StatisticsDaoFactory statisticsDaoFactory,
+                            @NotNull ExecutorServices executorServices) {
     myStatisticsDao = statisticsDaoFactory.get();
     myStatistics = myStatisticsDao.read();
     StatisticsReporter instance = this;

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/persistent/StatisticsReporter.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/persistent/StatisticsReporter.java
@@ -13,7 +13,7 @@ import jetbrains.buildServer.util.StringUtil;
 
 public class StatisticsReporter {
   private final StatisticsDao myStatisticsDao;
-  private Statistics myStatistics;
+  private final Statistics myStatistics;
 
   public StatisticsReporter(StatisticsDaoFactory statisticsDaoFactory,
                             ExecutorServices executorServices) {

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/processing/ModificationAnalyzerFactory.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/processing/ModificationAnalyzerFactory.java
@@ -82,15 +82,13 @@ public class ModificationAnalyzerFactory {
 
   @Nullable
   private static String findBrokenFile(@NotNull final SVcsModification vcsChange, @NotNull final String problemText) {
-    for (VcsFileModification modification : vcsChange.getChanges()) {
-      final String filePath = modification.getRelativeFileName();
-      for (String pattern : getPatterns(filePath)) {
-        if (problemText.contains(pattern)) {
-          return filePath;
-        }
-      }
-    }
-    return null;
+    return vcsChange.getChanges()
+      .stream()
+      .map(VcsFileModification::getRelativeFileName)
+      .filter(filePath -> getPatterns(filePath).stream()
+                                               .anyMatch(problemText::contains))
+      .findFirst()
+      .orElse(null);
   }
 
   /**

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/representation/ClickAssignButtonReportController.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/representation/ClickAssignButtonReportController.java
@@ -15,13 +15,14 @@ import org.springframework.web.servlet.ModelAndView;
 public class ClickAssignButtonReportController extends BaseController {
 
   private final StatisticsReporter myStatisticsReporter;
+  private final static String CONTROLLER_URL = "/autoAssignerStatisticsReporter.html";
 
   public ClickAssignButtonReportController(@NotNull final SBuildServer server,
                                            @NotNull final WebControllerManager controllerManager,
                                            @NotNull final StatisticsReporter statisticsReporter) {
     super(server);
     myStatisticsReporter = statisticsReporter;
-    controllerManager.registerController("/autoAssignerStatisticsReporter.html", this);
+    controllerManager.registerController(CONTROLLER_URL, this);
   }
 
   @Nullable

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/BuildProblemProcessor.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/BuildProblemProcessor.java
@@ -1,0 +1,2 @@
+package jetbrains.buildServer.investigationsAutoAssigner.utils;public interface BuildProblemProcessor {
+}

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/InvestigationsManager.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/InvestigationsManager.java
@@ -124,7 +124,7 @@ public class InvestigationsManager {
   }
 
   @NotNull
-  public HashMap<Long, User> findInAudit(@NotNull final Iterable<STestRun> sTestRuns, @NotNull SProject project) {
+  public Map<Long, User> findInAudit(@NotNull final Iterable<STestRun> sTestRuns, @NotNull SProject project) {
     AuditLogBuilder builder = myAuditLogProvider.getBuilder();
     builder.setActionTypes(ActionType.TEST_MARK_AS_FIXED, ActionType.TEST_INVESTIGATION_ASSIGN);
     List<String> projectIds = collectProjectHierarchyIds(project);
@@ -139,7 +139,7 @@ public class InvestigationsManager {
     }
     builder.setObjectIds(objectIds);
     List<AuditLogAction> lastActions = builder.getLogActions(-1);
-    HashMap<Long, User> result = new HashMap<>();
+    Map<Long, User> result = new HashMap<>();
     for (AuditLogAction action : lastActions) {
       for (ObjectWrapper obj : action.getObjects()) {
         Object user = obj.getObject();

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/ProblemTextExtractor.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/ProblemTextExtractor.java
@@ -30,12 +30,9 @@ public class ProblemTextExtractor {
       final Integer compileBlockIndex = getCompileBlockIndex(problem);
       if (compileBlockIndex != null) {
         AtomicInteger maxErrors = new AtomicInteger(TeamCityProperties.getInteger(Constants.MAX_COMPILE_ERRORS_TO_PROCESS, 100));
-        BuildLogCompileErrorCollector.collectCompileErrors(compileBlockIndex, build, new ItemProcessor<LogMessage>() {
-          @Override
-          public boolean processItem(final LogMessage item) {
-            problemSpecificText.append(item.getText()).append(" ");
-            return maxErrors.decrementAndGet() > 0;
-          }
+        BuildLogCompileErrorCollector.collectCompileErrors(compileBlockIndex, build, item -> {
+          problemSpecificText.append(item.getText()).append(" ");
+          return maxErrors.decrementAndGet() > 0;
         });
       }
     }

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/ProblemTextExtractor.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/ProblemTextExtractor.java
@@ -2,21 +2,13 @@
 
 package jetbrains.buildServer.investigationsAutoAssigner.utils;
 
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import jetbrains.buildServer.BuildProblemTypes;
-import jetbrains.buildServer.investigationsAutoAssigner.common.Constants;
-import jetbrains.buildServer.investigationsAutoAssigner.utils.errors.BuildProblemProcessor;
 import jetbrains.buildServer.investigationsAutoAssigner.utils.errors.BuildProblemProcessorFactory;
+import jetbrains.buildServer.investigationsAutoAssigner.utils.errors.BuildProblemProcessorNotFoundException;
 import jetbrains.buildServer.serverSide.SBuild;
 import jetbrains.buildServer.serverSide.STest;
 import jetbrains.buildServer.serverSide.STestRun;
-import jetbrains.buildServer.serverSide.TeamCityProperties;
-import jetbrains.buildServer.serverSide.buildLog.LogMessage;
-import jetbrains.buildServer.serverSide.problems.BuildLogCompileErrorCollector;
 import jetbrains.buildServer.serverSide.problems.BuildProblem;
 import jetbrains.buildServer.tests.TestName;
-import jetbrains.buildServer.util.ItemProcessor;
 import jetbrains.buildServer.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -28,7 +20,7 @@ public class ProblemTextExtractor {
     return BuildProblemProcessorFactory.getProcessor(problem.getBuildProblemData().getType())
       .map(processor -> processor.process(problem, build, getCompileBlockIndex(problem)))
       .map(text -> text + " " + problem.getBuildProblemDescription())
-      .orElse("");
+      .orElseThrow(() -> new BuildProblemProcessorNotFoundException("Processor not found for problem type: " + problem.getBuildProblemData().getType()));
   }
 
   @Nullable

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/errors/BuildProblemProcessor.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/errors/BuildProblemProcessor.java
@@ -22,5 +22,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public interface BuildProblemProcessor {
+  /**
+   * Process build problem and return a string with the problem description.
+   *
+   * @param buildProblem the build problem to process
+   * @param build the build where the problem occurred
+   * @param compileBlockIndex the index of the compilation block in the build log
+   * @return the problem description
+   */
   String process(@NotNull BuildProblem buildProblem, @NotNull SBuild build, @Nullable Integer compileBlockIndex);
 }

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/errors/BuildProblemProcessor.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/errors/BuildProblemProcessor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jetbrains.buildServer.investigationsAutoAssigner.utils.errors;
+
+import jetbrains.buildServer.serverSide.SBuild;
+import jetbrains.buildServer.serverSide.problems.BuildProblem;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public interface BuildProblemProcessor {
+  String process(@NotNull BuildProblem buildProblem, @NotNull SBuild build, @Nullable Integer compileBlockIndex);
+}

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/errors/BuildProblemProcessorFactory.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/errors/BuildProblemProcessorFactory.java
@@ -16,6 +16,22 @@
 
 package jetbrains.buildServer.investigationsAutoAssigner.utils.errors;
 
-public class BuildProblemProcessorFactory {
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import jetbrains.buildServer.BuildProblemTypes;
+import org.jetbrains.annotations.NotNull;
 
+public class BuildProblemProcessorFactory {
+  private final static Map<String, BuildProblemProcessor> processors = new HashMap<>();
+  static {
+    processors.put(BuildProblemTypes.TC_COMPILATION_ERROR_TYPE, new CompilationErrorProcessor());
+  }
+
+  private BuildProblemProcessorFactory() {
+  }
+
+  public static Optional<BuildProblemProcessor> getProcessor(@NotNull final String type) {
+    return Optional.ofNullable(processors.get(type));
+    }
 }

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/errors/BuildProblemProcessorFactory.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/errors/BuildProblemProcessorFactory.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jetbrains.buildServer.investigationsAutoAssigner.utils.errors;
+
+public class BuildProblemProcessorFactory {
+}

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/errors/BuildProblemProcessorFactory.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/errors/BuildProblemProcessorFactory.java
@@ -17,4 +17,5 @@
 package jetbrains.buildServer.investigationsAutoAssigner.utils.errors;
 
 public class BuildProblemProcessorFactory {
+
 }

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/errors/BuildProblemProcessorNotFoundException.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/errors/BuildProblemProcessorNotFoundException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jetbrains.buildServer.investigationsAutoAssigner.utils.errors;
+
+public class BuildProblemProcessorNotFoundException extends RuntimeException {
+  public BuildProblemProcessorNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/errors/CompilationErrorProcessor.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/errors/CompilationErrorProcessor.java
@@ -37,6 +37,6 @@ public class CompilationErrorProcessor implements BuildProblemProcessor {
         return maxErrors.decrementAndGet() > 0;
       });
     }
-    return problemSpecificText + " " + buildProblem.getBuildProblemDescription();
+    return problemSpecificText.toString();
   }
 }

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/errors/CompilationErrorProcessor.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/errors/CompilationErrorProcessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jetbrains.buildServer.investigationsAutoAssigner.utils.errors;
+
+import jetbrains.buildServer.serverSide.SBuild;
+import jetbrains.buildServer.serverSide.problems.BuildProblem;
+import org.jetbrains.annotations.NotNull;
+
+public class CompilationErrorProcessor implements BuildProblemProcessor {
+  @Override
+  public String process(@NotNull final BuildProblem buildProblem, @NotNull final SBuild build) {
+    return null;
+  }
+}


### PR DESCRIPTION
## Partial refactor of the code base
### Use Streams Instead of For-Loops
Refactored parts of the codebase by replacing some for-loops with the `Stream API`, improving readability and conciseness.
### Use Map Interface Instead of HashMap
Modified the return type of `findInAudit` to `Map` instead of `HashMap`. This change allows returning any type of `Map` without explicitly specifying the implementation class, improving flexibility.
### Build Problem Handling
* Created a new interface, `BuildProblemProcessor`, to handle different types of `BuildProblemTypes`. This introduces a generic approach to processing various problems with distinct logic.
* Introduced `BuildProblemProcessorFactory`, which automatically returns the appropriate problem processor based on the issue type.
* Refactored `ProblemTextExtractor` to use this new logic, effectively abstracting error handling and improving separation of concerns.