### PR TITLE
Partial refactoring, new tests

### DIFF
--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/common/Constants.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/common/Constants.java
@@ -32,6 +32,8 @@ public class Constants {
 
   public static final String MAX_COMPILE_ERRORS_TO_PROCESS = "teamcity.investigationsAutoAssigner.maxCompileErrorsToProcess";
 
+  public static int DEFAULT_MAX_COMPILE_ERRORS_TO_PROCESS = 100;
+
   public static final String IGNORE_SETUP_TEARDOWN_METHODS = "teamcity.investigationsAutoAssigner.ignoreSetupAndTearDown";
 
   public static final String PREFERRED_INVESTIGATION_PROJECT = "teamcity.internal.preferredInvestigationProject";

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/heuristics/BrokenFileHeuristic.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/heuristics/BrokenFileHeuristic.java
@@ -72,7 +72,7 @@ public class BrokenFileHeuristic implements Heuristic {
     SBuild sBuild = heuristicContext.getBuild();
 
     for (STestRun sTestRun : heuristicContext.getTestRuns()) {
-      String problemText = myProblemTextExtractor.getBuildProblemText(sTestRun);
+      String problemText = myProblemTextExtractor.getFailedTestText(sTestRun);
       Responsibility responsibility = findResponsibleUser(vcsChanges, problemText, heuristicContext);
       if (responsibility != null) {
         result.addResponsibility(sTestRun, responsibility);

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/BuildProblemTextExtractor.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/BuildProblemTextExtractor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jetbrains.buildServer.investigationsAutoAssigner.utils;
+
+import jetbrains.buildServer.serverSide.SBuild;
+import jetbrains.buildServer.serverSide.problems.BuildProblem;
+import org.jetbrains.annotations.NotNull;
+
+public interface BuildProblemTextExtractor {
+  @NotNull
+  String extractText(@NotNull BuildProblem problem, @NotNull SBuild build);
+}

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/CompilationErrorTextExtractor.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/CompilationErrorTextExtractor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jetbrains.buildServer.investigationsAutoAssigner.utils;
+
+import jetbrains.buildServer.BuildProblemTypes;
+import jetbrains.buildServer.investigationsAutoAssigner.common.Constants;
+import jetbrains.buildServer.serverSide.SBuild;
+import jetbrains.buildServer.serverSide.problems.BuildLogCompileErrorCollector;
+import jetbrains.buildServer.serverSide.problems.BuildProblem;
+import jetbrains.buildServer.util.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import java.util.concurrent.atomic.AtomicInteger;
+import jetbrains.buildServer.serverSide.TeamCityProperties;
+
+
+import static jetbrains.buildServer.serverSide.impl.problems.types.CompilationErrorTypeDetailsProvider.COMPILE_BLOCK_INDEX;
+
+public class CompilationErrorTextExtractor implements BuildProblemTextExtractor {
+  @NotNull
+  @Override
+  public String extractText(@NotNull final BuildProblem problem, @NotNull final SBuild build) {
+    StringBuilder problemSpecificText = new StringBuilder();
+
+    if (problem.getBuildProblemData().getType().equals(BuildProblemTypes.TC_COMPILATION_ERROR_TYPE)) {
+      final Integer compileBlockIndex = getCompileBlockIndex(problem);
+      if (compileBlockIndex != null) {
+        AtomicInteger maxErrors = new AtomicInteger(TeamCityProperties.getInteger(Constants.MAX_COMPILE_ERRORS_TO_PROCESS, Constants.DEFAULT_MAX_COMPILE_ERRORS_TO_PROCESS));
+        BuildLogCompileErrorCollector.collectCompileErrors(compileBlockIndex, build, item -> {
+          problemSpecificText.append(item.getText()).append(" ");
+          return maxErrors.decrementAndGet() > 0;
+        });
+      }
+    }
+
+    return problemSpecificText + " " + problem.getBuildProblemDescription();
+  }
+
+  @Nullable
+  private static Integer getCompileBlockIndex(@NotNull final BuildProblem problem) {
+    final String compilationBlockIndex = problem.getBuildProblemData().getAdditionalData();
+    if (compilationBlockIndex == null) return null;
+
+    try {
+      return Integer.parseInt(
+        StringUtil.stringToProperties(compilationBlockIndex, StringUtil.STD_ESCAPER2).get(COMPILE_BLOCK_INDEX));
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+}

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/ProblemTextExtractor.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/utils/ProblemTextExtractor.java
@@ -2,61 +2,38 @@
 
 package jetbrains.buildServer.investigationsAutoAssigner.utils;
 
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.HashMap;
+import java.util.Map;
 import jetbrains.buildServer.BuildProblemTypes;
-import jetbrains.buildServer.investigationsAutoAssigner.common.Constants;
 import jetbrains.buildServer.serverSide.SBuild;
 import jetbrains.buildServer.serverSide.STest;
 import jetbrains.buildServer.serverSide.STestRun;
-import jetbrains.buildServer.serverSide.TeamCityProperties;
-import jetbrains.buildServer.serverSide.buildLog.LogMessage;
-import jetbrains.buildServer.serverSide.problems.BuildLogCompileErrorCollector;
 import jetbrains.buildServer.serverSide.problems.BuildProblem;
 import jetbrains.buildServer.tests.TestName;
-import jetbrains.buildServer.util.ItemProcessor;
-import jetbrains.buildServer.util.StringUtil;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-import static jetbrains.buildServer.serverSide.impl.problems.types.CompilationErrorTypeDetailsProvider.COMPILE_BLOCK_INDEX;
+import org.jetbrains.annotations.NotNull;
+
 
 public class ProblemTextExtractor {
-  public String getBuildProblemText(@NotNull final BuildProblem problem, @NotNull final SBuild build) {
-    StringBuilder problemSpecificText = new StringBuilder();
+  private final Map<String, BuildProblemTextExtractor> textExtractorsMap = new HashMap<>();
+  private final BuildProblemTextExtractor defaultExtractor;
 
-    // todo make an extension point here
-    if (problem.getBuildProblemData().getType().equals(BuildProblemTypes.TC_COMPILATION_ERROR_TYPE)) {
-      final Integer compileBlockIndex = getCompileBlockIndex(problem);
-      if (compileBlockIndex != null) {
-        AtomicInteger maxErrors = new AtomicInteger(TeamCityProperties.getInteger(Constants.MAX_COMPILE_ERRORS_TO_PROCESS, 100));
-        BuildLogCompileErrorCollector.collectCompileErrors(compileBlockIndex, build, new ItemProcessor<LogMessage>() {
-          @Override
-          public boolean processItem(final LogMessage item) {
-            problemSpecificText.append(item.getText()).append(" ");
-            return maxErrors.decrementAndGet() > 0;
-          }
-        });
-      }
-    }
+  public ProblemTextExtractor() {
+    this.textExtractorsMap.put(BuildProblemTypes.TC_COMPILATION_ERROR_TYPE, new CompilationErrorTextExtractor());
 
-    return problemSpecificText + " " + problem.getBuildProblemDescription();
+    this.defaultExtractor = (problem, build) -> {
+      String description = problem.getBuildProblemDescription();
+      return description != null ? description : "no problem description available";
+    };
+  }
+  public String getBuildProblemText(@NotNull BuildProblem problem, @NotNull SBuild build) {
+    String type = problem.getBuildProblemData().getType();
+    BuildProblemTextExtractor extractor = textExtractorsMap.getOrDefault(type, defaultExtractor);
+    return extractor.extractText(problem, build);
   }
 
-  @Nullable
-  private static Integer getCompileBlockIndex(@NotNull final BuildProblem problem) {
-    final String compilationBlockIndex = problem.getBuildProblemData().getAdditionalData();
-    if (compilationBlockIndex == null) return null;
 
-    try {
-      return Integer.parseInt(
-        StringUtil.stringToProperties(compilationBlockIndex, StringUtil.STD_ESCAPER2).get(COMPILE_BLOCK_INDEX));
-    } catch (Exception e) {
-      return null;
-    }
-  }
-
-  public String getBuildProblemText(STestRun sTestRun) {
+  public String getFailedTestText(@NotNull STestRun sTestRun) {
     final STest test = sTestRun.getTest();
     final TestName testName = test.getName();
     return testName.getAsString() + " " + sTestRun.getFullText();

--- a/src/test/java/jetbrains/buildServer/investigationsAutoAssigner/heuristics/BrokenFileHeuristicTest.java
+++ b/src/test/java/jetbrains/buildServer/investigationsAutoAssigner/heuristics/BrokenFileHeuristicTest.java
@@ -63,7 +63,7 @@ public class BrokenFileHeuristicTest extends BaseTestCase {
                                               Collections.emptySet());
     myBuildPromotion = Mockito.mock(BuildPromotionEx.class);
     when(SBuild.getBuildPromotion()).thenReturn(myBuildPromotion);
-    when(myProblemTextExtractor.getBuildProblemText(any())).thenReturn("I contain ./path1/path1/path1/filename");
+    when(myProblemTextExtractor.getFailedTestText(any())).thenReturn("I contain ./path1/path1/path1/filename");
     myChangeDescriptor = Mockito.mock(ChangeDescriptor.class);
     final SVcsModification vcsModification = Mockito.mock(SVcsModification.class);
     when(myChangeDescriptor.getRelatedVcsChange()).thenReturn(vcsModification);
@@ -120,7 +120,7 @@ public class BrokenFileHeuristicTest extends BaseTestCase {
   public void TestCorrectCase() {
     String filePath = "./path1/path1/path1/filename";
     String theProblemText = "I contain " + filePath;
-    when(myProblemTextExtractor.getBuildProblemText(any())).thenReturn(theProblemText);
+    when(myProblemTextExtractor.getFailedTestText(any())).thenReturn(theProblemText);
 
     Pair<User, String> result = Pair.create(myUser, filePath);
     when(myFirstVcsChangeWrapped.findProblematicFile(theProblemText, Collections.emptySet())).thenReturn(result);
@@ -147,7 +147,7 @@ public class BrokenFileHeuristicTest extends BaseTestCase {
     String firstFilePath = "./path1/path1/path1/filename";
     String secondFilePath = "./path4/path4/path4/filename";
     String theProblemText = "I contain " + firstFilePath + "and" + secondFilePath;
-    when(myProblemTextExtractor.getBuildProblemText(any())).thenReturn(theProblemText);
+    when(myProblemTextExtractor.getFailedTestText(any())).thenReturn(theProblemText);
 
     Pair<User, String> firstResult = Pair.create(myUser, firstFilePath);
     Pair<User, String> secondResult = Pair.create(mySecondUser, secondFilePath);

--- a/src/test/java/jetbrains/buildServer/investigationsAutoAssigner/utils/ProblemTextExtractorTest.java
+++ b/src/test/java/jetbrains/buildServer/investigationsAutoAssigner/utils/ProblemTextExtractorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jetbrains.buildServer.investigationsAutoAssigner.utils;
+
+
+import jetbrains.buildServer.BuildProblemData;
+import jetbrains.buildServer.BuildProblemTypes;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import jetbrains.buildServer.serverSide.SBuild;
+import jetbrains.buildServer.serverSide.STest;
+import jetbrains.buildServer.serverSide.STestRun;
+import jetbrains.buildServer.serverSide.problems.BuildProblem;
+import jetbrains.buildServer.tests.TestName;
+
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+public class ProblemTextExtractorTest {
+
+  private ProblemTextExtractor problemTextExtractor;
+  private BuildProblem buildProblem;
+  private SBuild sBuild;
+  private STest sTest;
+  private STestRun sTestRun;
+  private TestName testName;
+
+  @BeforeMethod
+  public void setUp() {
+    problemTextExtractor = new ProblemTextExtractor();
+    buildProblem = mock(BuildProblem.class);
+    sBuild = mock(SBuild.class);
+    sTest = mock(STest.class);
+    sTestRun = mock(STestRun.class);
+    testName = mock(TestName.class);
+  }
+
+  @Test
+  public void testGetBuildProblemText_WithCompilationError() {
+    when(buildProblem.getBuildProblemData()).thenReturn(mock(BuildProblemData.class));
+    when(buildProblem.getBuildProblemData().getType()).thenReturn(BuildProblemTypes.TC_COMPILATION_ERROR_TYPE);
+    when(buildProblem.getBuildProblemDescription()).thenReturn("Compilation Error Description");
+
+    String result = problemTextExtractor.getBuildProblemText(buildProblem, sBuild);
+
+    assertTrue(result.contains("Compilation Error Description"), "The result should contain a description of the compilation error");
+  }
+
+  @Test
+  public void testGetBuildProblemText_WithDefaultExtractor() {
+    when(buildProblem.getBuildProblemData()).thenReturn(mock(BuildProblemData.class));
+    when(buildProblem.getBuildProblemData().getType()).thenReturn("UNKNOWN_ERROR");
+    when(buildProblem.getBuildProblemDescription()).thenReturn("Generic Error Description");
+
+    String result = problemTextExtractor.getBuildProblemText(buildProblem, sBuild);
+
+    assertEquals(result, "Generic Error Description");
+  }
+
+  @Test
+  public void testGetBuildProblemText_EmptyDescription() {
+    when(buildProblem.getBuildProblemData()).thenReturn(mock(BuildProblemData.class));
+    when(buildProblem.getBuildProblemData().getType()).thenReturn("UNKNOWN_ERROR");
+    when(buildProblem.getBuildProblemDescription()).thenReturn(null);
+
+    String result = problemTextExtractor.getBuildProblemText(buildProblem, sBuild);
+
+    assertEquals(result, "no problem description available");
+  }
+
+  @Test
+  public void testGetFailedTestText() {
+    when(sTestRun.getTest()).thenReturn(sTest);
+    when(sTest.getName()).thenReturn(testName);
+    when(testName.getAsString()).thenReturn("testExampleName");
+    when(sTestRun.getFullText()).thenReturn("test failed with assertion error");
+
+    String result = problemTextExtractor.getFailedTestText(sTestRun);
+
+    assertEquals(result, "testExampleName test failed with assertion error");
+  }
+}


### PR DESCRIPTION
### Summary of changes

1. **Refactoring of the `ProblemTextExtractor` class:**

- Introduced a more extensible structure for generating problem-specific text using a `textExtractorsMap`, which maps problem types to dedicated text extractors.  
- Added the `BuildProblemTextExtractor` interface to encapsulate logic for generating problem-specific text.  
- Implemented `CompilationErrorTextExtractor` as a specific extractor for extracting text from compilation errors.  
- `ProblemTextExtractor` now delegates text extraction for specific problems to the appropriate extractor based on the problem type, improving readability and scalability.  
- Renamed the method `getBuildProblemText(STestRun)` to `getFailedTestText(STestRun)` to better reflect its responsibility and added the `@NotNull` annotation.  

2. **Simplified the body of the previous `getBuildProblemText(SBuild)` method (now this code is in the `CompilationErrorTextExtractor` class):**

- Replaced the anonymous class used for error processing with a lambda expression for improved conciseness and readability.  
- Introduced and used the constant `DEFAULT_MAX_COMPILE_ERRORS_TO_PROCESS`, replacing the previous hardcoded value.  

3. **Added unit tests for the refactored `ProblemTextExtractor` class:**

- `testGetBuildProblemText_WithCompilationError`: Verifies that compilation error text is correctly included in the result.  
- `testGetBuildProblemText_WithDefaultExtractor`: Verifies that in the default case, the build problem description is correctly included in the result.  
- `testGetBuildProblemText_EmptyDescription`: Verifies that in the default case, when no build problem description is available, a default error text is returned.  
- `testGetFailedTestText`: Verifies that the test run description (test name and full text) is correctly included in the result.

**Changes have been tested and existing functionality is preserved.**