### PR TITLE
Refactoring "Favourite Build Assigner"

### DIFF
--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/common/Constants.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/common/Constants.java
@@ -27,7 +27,6 @@ public class Constants {
 
   // Server internal properties
   public static final String PROCESSING_DELAY_IN_SECONDS = "teamcity.investigationsAutoAssigner.scheduledTaskInterval.seconds";
-  public static final String SHOULD_AUTOMATICALLY_MARK_IMPORTANT_BUILDS_AS_FAVORITE = "teamcity.properties.automaticallyMarkImportantBuildsAsFavorite.enabled";
 
   // Server internal properties (debug use only)
   public static final String STATISTICS_ENABLED = "teamcity.investigationsAutoAssigner.statisticsEnabled";

--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/processing/AbstractFavoriteBuildAssigner.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/processing/AbstractFavoriteBuildAssigner.java
@@ -37,8 +37,7 @@ public abstract class AbstractFavoriteBuildAssigner {
    * @return a boolean representing if it is possible to mark continue the procedure of marking.
    */
   protected boolean shouldMarkAsFavorite(@NotNull final SUser user) {
-    return TeamCityProperties.getBoolean(Constants.SHOULD_AUTOMATICALLY_MARK_IMPORTANT_BUILDS_AS_FAVORITE) &&
-           user.getBooleanProperty(new SimplePropertyKey(Constants.USER_AUTOMATICALLY_MARK_IMPORTANT_BUILDS_AS_FAVORITE_INTERNAL_PROPERTY));
+    return user.getBooleanProperty(new SimplePropertyKey(Constants.USER_AUTOMATICALLY_MARK_IMPORTANT_BUILDS_AS_FAVORITE_INTERNAL_PROPERTY));
   }
 
   /**

--- a/src/test/java/jetbrains/buildServer/investigationsAutoAssigner/processing/FavoriteBuildAssignerTest.java
+++ b/src/test/java/jetbrains/buildServer/investigationsAutoAssigner/processing/FavoriteBuildAssignerTest.java
@@ -57,27 +57,14 @@ public class FavoriteBuildAssignerTest extends BaseTestCase {
     myFavoriteBuildAssigner = new FavoriteBuildAssigner(myFavoriteBuildsManager);
   }
 
-  public void Test_TeamCityPropertyDisabledUsersCheckboxTrue() {
-    when(myUser1.getPropertyValue(new SimplePropertyKey(Constants.USER_AUTOMATICALLY_MARK_IMPORTANT_BUILDS_AS_FAVORITE_INTERNAL_PROPERTY))).thenReturn("true");
-    myFavoriteBuildAssigner.markAsFavorite(mySBuild, myUser1);
-    Mockito.verify(myFavoriteBuildsManager, Mockito.never()).tagBuild(mySBuild.getBuildPromotion(), myUser1);
-  }
-
-  public void Test_TeamCityPropertyDisabledUsersCheckboxFalse() {
-    myFavoriteBuildAssigner.markAsFavorite(mySBuild, myUser1);
-    Mockito.verify(myFavoriteBuildsManager, Mockito.never()).tagBuild(mySBuild.getBuildPromotion(), myUser1);
-  }
-
-  public void Test_TeamCityPropertyEnabledUsersCheckboxFalse() {
-    setInternalProperty(Constants.SHOULD_AUTOMATICALLY_MARK_IMPORTANT_BUILDS_AS_FAVORITE, "true");
-    myFavoriteBuildAssigner.markAsFavorite(mySBuild, myUser1);
-    Mockito.verify(myFavoriteBuildsManager, Mockito.never()).tagBuild(mySBuild.getBuildPromotion(), myUser1);
-  }
-
-  public void Test_TeamCityPropertyEnabledUsersCheckboxTrue() {
-    setInternalProperty(Constants.SHOULD_AUTOMATICALLY_MARK_IMPORTANT_BUILDS_AS_FAVORITE, "true");
+  public void Test_UsersCheckboxTrue() {
     when(myUser1.getBooleanProperty(new SimplePropertyKey(Constants.USER_AUTOMATICALLY_MARK_IMPORTANT_BUILDS_AS_FAVORITE_INTERNAL_PROPERTY))).thenReturn(true);
     myFavoriteBuildAssigner.markAsFavorite(mySBuild, myUser1);
     Mockito.verify(myFavoriteBuildsManager, Mockito.only()).tagBuild(mySBuild.getBuildPromotion(), myUser1);
+  }
+
+  public void Test_CheckboxFalse() {
+    myFavoriteBuildAssigner.markAsFavorite(mySBuild, myUser1);
+    Mockito.verify(myFavoriteBuildsManager, Mockito.never()).tagBuild(mySBuild.getBuildPromotion(), myUser1);
   }
 }


### PR DESCRIPTION
## Refactor FavoriteBuildAssigner logic and Its dependencies

1. Remove from Constants the TeamCity internal property
2. Change the 'shouldMarkAsFavorite' logic, check only the user's checkbox value
3. Change FavoriteBuildAssignerTest class, remove all the combinations in pair with the TeamCity internal property and only check the user's checkbox value